### PR TITLE
Add support for gradients

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -5,7 +5,8 @@
     ".": "./src/index.ts",
     "./supports": "./src/supports.ts",
     "./utils": "./src/utils.ts",
-    "./fast": "./src/fast.ts"
+    "./fast": "./src/fast.ts",
+    "./gradients": "./src/gradients.ts"
   },
   "exclude": [
     "tsup.config.ts",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,16 @@
         "default": "./dist/utils.cjs"
       }
     },
+    "./gradients": {
+      "import": {
+        "types": "./dist/gradients.d.ts",
+        "default": "./dist/gradients.mjs"
+      },
+      "require": {
+        "types": "./dist/gradients.d.cts",
+        "default": "./dist/gradients.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.cjs",

--- a/src/gradients.ts
+++ b/src/gradients.ts
@@ -1,0 +1,38 @@
+import { hexToRgb, rgbToAnsi256 } from "./utils";
+
+type GradientFunction = (text: string) => string;
+
+export function gradient(colors: string[]): GradientFunction {
+  const rgbColors = colors.map(hexToRgb);
+  return (text: string) => {
+    const length = text.length;
+    return text
+      .split("")
+      .map((char, index) => {
+        const colorIndex = Math.floor((index / length) * (rgbColors.length - 1));
+        const [r, g, b] = rgbColors[colorIndex];
+        const ansiCode = rgbToAnsi256(r, g, b);
+        return `\x1B[38;5;${ansiCode}m${char}\x1B[39m`;
+      })
+      .join("");
+  };
+}
+
+export const mijd = gradient(["#FF0000", "#00FF00", "#0000FF"]);
+export const vice = gradient(["#FF00FF", "#00FFFF", "#FFFF00"]);
+export const fruit = gradient(["#FF6347", "#FFD700", "#ADFF2F"]);
+export const retro = gradient(["#FF4500", "#32CD32", "#1E90FF"]);
+export const summer = gradient(["#FFD700", "#FF8C00", "#FF4500"]);
+export const rainbow = gradient(["#FF0000", "#FF7F00", "#FFFF00", "#00FF00", "#0000FF", "#4B0082", "#8B00FF"]);
+export const pastel = gradient(["#FFB6C1", "#FFDAB9", "#E6E6FA"]);
+
+export default {
+  gradient,
+  mijd,
+  vice,
+  fruit,
+  retro,
+  summer,
+  rainbow,
+  pastel,
+};

--- a/test/gradients.test.ts
+++ b/test/gradients.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { gradient, mijd, vice, fruit, retro, summer, rainbow, pastel } from "../src/gradients";
+
+describe("gradient function", () => {
+  it("should apply gradient to text", () => {
+    const grad = gradient(["#FF0000", "#00FF00", "#0000FF"]);
+    const result = grad("Hello, World!");
+    expect(result).toMatch(/\x1B\[38;5;\d+mH\x1B\[39m\x1B\[38;5;\d+me\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+mo\x1B\[39m\x1B\[38;5;\d+m,\x1B\[39m\x1B\[38;5;\d+m \x1B\[39m\x1B\[38;5;\d+mW\x1B\[39m\x1B\[38;5;\d+mo\x1B\[39m\x1B\[38;5;\d+mr\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+md\x1B\[39m\x1B\[38;5;\d+m!\x1B\[39m/);
+  });
+});
+
+describe("builtin gradients", () => {
+  it("should apply mijd gradient", () => {
+    const result = mijd("Hello, World!");
+    expect(result).toMatch(/\x1B\[38;5;\d+mH\x1B\[39m\x1B\[38;5;\d+me\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+mo\x1B\[39m\x1B\[38;5;\d+m,\x1B\[39m\x1B\[38;5;\d+m \x1B\[39m\x1B\[38;5;\d+mW\x1B\[39m\x1B\[38;5;\d+mo\x1B\[39m\x1B\[38;5;\d+mr\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+md\x1B\[39m\x1B\[38;5;\d+m!\x1B\[39m/);
+  });
+
+  it("should apply vice gradient", () => {
+    const result = vice("Hello, World!");
+    expect(result).toMatch(/\x1B\[38;5;\d+mH\x1B\[39m\x1B\[38;5;\d+me\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+mo\x1B\[39m\x1B\[38;5;\d+m,\x1B\[39m\x1B\[38;5;\d+m \x1B\[39m\x1B\[38;5;\d+mW\x1B\[39m\x1B\[38;5;\d+mo\x1B\[39m\x1B\[38;5;\d+mr\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+md\x1B\[39m\x1B\[38;5;\d+m!\x1B\[39m/);
+  });
+
+  it("should apply fruit gradient", () => {
+    const result = fruit("Hello, World!");
+    expect(result).toMatch(/\x1B\[38;5;\d+mH\x1B\[39m\x1B\[38;5;\d+me\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+mo\x1B\[39m\x1B\[38;5;\d+m,\x1B\[39m\x1B\[38;5;\d+m \x1B\[39m\x1B\[38;5;\d+mW\x1B\[39m\x1B\[38;5;\d+mo\x1B\[39m\x1B\[38;5;\d+mr\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+md\x1B\[39m\x1B\[38;5;\d+m!\x1B\[39m/);
+  });
+
+  it("should apply retro gradient", () => {
+    const result = retro("Hello, World!");
+    expect(result).toMatch(/\x1B\[38;5;\d+mH\x1B\[39m\x1B\[38;5;\d+me\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+mo\x1B\[39m\x1B\[38;5;\d+m,\x1B\[39m\x1B\[38;5;\d+m \x1B\[39m\x1B\[38;5;\d+mW\x1B\[39m\x1B\[38;5;\d+mo\x1B\[39m\x1B\[38;5;\d+mr\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+md\x1B\[39m\x1B\[38;5;\d+m!\x1B\[39m/);
+  });
+
+  it("should apply summer gradient", () => {
+    const result = summer("Hello, World!");
+    expect(result).toMatch(/\x1B\[38;5;\d+mH\x1B\[39m\x1B\[38;5;\d+me\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+mo\x1B\[39m\x1B\[38;5;\d+m,\x1B\[39m\x1B\[38;5;\d+m \x1B\[39m\x1B\[38;5;\d+mW\x1B\[39m\x1B\[38;5;\d+mo\x1B\[39m\x1B\[38;5;\d+mr\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+md\x1B\[39m\x1B\[38;5;\d+m!\x1B\[39m/);
+  });
+
+  it("should apply rainbow gradient", () => {
+    const result = rainbow("Hello, World!");
+    expect(result).toMatch(/\x1B\[38;5;\d+mH\x1B\[39m\x1B\[38;5;\d+me\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+mo\x1B\[39m\x1B\[38;5;\d+m,\x1B\[39m\x1B\[38;5;\d+m \x1B\[39m\x1B\[38;5;\d+mW\x1B\[39m\x1B\[38;5;\d+mo\x1B\[39m\x1B\[38;5;\d+mr\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+md\x1B\[39m\x1B\[38;5;\d+m!\x1B\[39m/);
+  });
+
+  it("should apply pastel gradient", () => {
+    const result = pastel("Hello, World!");
+    expect(result).toMatch(/\x1B\[38;5;\d+mH\x1B\[39m\x1B\[38;5;\d+me\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+mo\x1B\[39m\x1B\[38;5;\d+m,\x1B\[39m\x1B\[38;5;\d+m \x1B\[39m\x1B\[38;5;\d+mW\x1B\[39m\x1B\[38;5;\d+mo\x1B\[39m\x1B\[38;5;\d+mr\x1B\[39m\x1B\[38;5;\d+ml\x1B\[39m\x1B\[38;5;\d+md\x1B\[39m\x1B\[38;5;\d+m!\x1B\[39m/);
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     "./src/supports.ts",
     "./src/utils.ts",
     "./src/fast.ts",
+    "./src/gradients.ts",
   ],
   format: ["cjs", "esm"],
   platform: "node",


### PR DESCRIPTION
Fixes #49

Add support for gradients with a new API.

* **New Gradient API**: Add `src/gradients.ts` implementing the `gradient` function and built-in gradients (`mijd`, `vice`, `fruit`, `retro`, `summer`, `rainbow`, `pastel`).
* **Exports**: Update `package.json` and `jsr.json` to include the new export `farver/gradients`.
* **Build Configuration**: Modify `tsup.config.ts` to add `./src/gradients.ts` to the `entry` array.
* **Tests**: Add `test/gradients.test.ts` with tests for the `gradient` function and the built-in gradients.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/luxass/farver/pull/78?shareId=3b075122-59c7-48a6-b980-40f3a72e69ae).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new gradient text rendering feature that applies smooth color transitions to text.
	- Added several preset gradient styles (e.g., mijd, vice, fruit, retro, summer, rainbow, pastel) to enhance text styling.
	- Improved module support to provide this functionality in various import formats.

- **Tests**
	- Added unit tests to verify the proper application of gradient effects to text output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->